### PR TITLE
fix: `when` and `not` pattern type is not fixed by the function type

### DIFF
--- a/.changeset/afraid-garlics-walk.md
+++ b/.changeset/afraid-garlics-walk.md
@@ -1,0 +1,5 @@
+---
+"@effect/match": patch
+---
+
+fix pattern type derivation for `when` and `not`

--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -128,12 +128,16 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const not: <R, const P extends PatternPrimitive<R> | PatternBase<R>, B>(
+export declare const not: <
+  R,
+  const P extends PatternPrimitive<R> | PatternBase<R>,
+  Fn extends (_: Exclude<R, ExtractMatch<R, SafeSchemaR<PredToSchema<P>>>>) => unknown
+>(
   pattern: P,
-  f: (_: Exclude<R, ExtractMatch<R, SafeSchemaR<PredToSchema<P>>>>) => B
+  f: Fn
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr>
-) => Matcher<I, AddOnly<F, WhenMatch<R, P>>, ApplyFilters<I, AddOnly<F, WhenMatch<R, P>>>, B | A, Pr>
+) => Matcher<I, AddOnly<F, WhenMatch<R, P>>, ApplyFilters<I, AddOnly<F, WhenMatch<R, P>>>, A | ReturnType<Fn>, Pr>
 ```
 
 Added in v1.0.0
@@ -197,16 +201,20 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const when: <R, const P extends PatternPrimitive<R> | PatternBase<R>, B>(
+export declare const when: <
+  R,
+  const P extends PatternPrimitive<R> | PatternBase<R>,
+  Fn extends (_: WhenMatch<R, P>) => unknown
+>(
   pattern: P,
-  f: (_: WhenMatch<R, P>) => B
+  f: Fn
 ) => <I, F, A, Pr>(
   self: Matcher<I, F, R, A, Pr>
 ) => Matcher<
   I,
   AddWithout<F, SafeSchemaR<PredToSchema<P>>>,
   ApplyFilters<I, AddWithout<F, SafeSchemaR<PredToSchema<P>>>>,
-  B | A,
+  A | ReturnType<Fn>,
   Pr
 >
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,7 +217,11 @@ export const value = <I>(i: I): Matcher<I, Without<never>, I, never, I> =>
  * @since 1.0.0
  */
 export const when =
-  <R, const P extends PatternPrimitive<R> | PatternBase<R>, Fn extends (_: WhenMatch<R, P>) => unknown>(
+  <
+    R,
+    const P extends PatternPrimitive<R> | PatternBase<R>,
+    Fn extends (_: WhenMatch<R, P>) => unknown,
+  >(
     pattern: P,
     f: Fn,
   ) =>
@@ -238,8 +242,12 @@ export const when =
  * @since 1.0.0
  */
 export const whenOr =
-  <R, const P extends ReadonlyArray<PatternPrimitive<R> | PatternBase<R>>, B>(
-    ...args: [...patterns: P, f: (_: WhenMatch<R, P[number]>) => B]
+  <
+    R,
+    const P extends ReadonlyArray<PatternPrimitive<R> | PatternBase<R>>,
+    Fn extends (_: WhenMatch<R, P[number]>) => unknown,
+  >(
+    ...args: [...patterns: P, f: Fn]
   ) =>
   <I, F, A, Pr>(
     self: Matcher<I, F, R, A, Pr>,
@@ -247,7 +255,7 @@ export const whenOr =
     I,
     AddWithout<F, PForExclude<P[number]>>,
     ApplyFilters<I, AddWithout<F, PForExclude<P[number]>>>,
-    A | B,
+    A | ReturnType<Fn>,
     Pr
   > => {
     const onMatch = args[args.length - 1] as any
@@ -261,8 +269,12 @@ export const whenOr =
  * @since 1.0.0
  */
 export const whenAnd =
-  <R, const P extends ReadonlyArray<PatternPrimitive<R> | PatternBase<R>>, B>(
-    ...args: [...patterns: P, f: (_: WhenMatch<R, ArrayToIntersection<P>>) => B]
+  <
+    R,
+    const P extends ReadonlyArray<PatternPrimitive<R> | PatternBase<R>>,
+    Fn extends (_: WhenMatch<R, ArrayToIntersection<P>>) => unknown,
+  >(
+    ...args: [...patterns: P, f: Fn]
   ) =>
   <I, F, A, Pr>(
     self: Matcher<I, F, R, A, Pr>,
@@ -270,7 +282,7 @@ export const whenAnd =
     I,
     AddWithout<F, PForExclude<ArrayToIntersection<P>>>,
     ApplyFilters<I, AddWithout<F, PForExclude<ArrayToIntersection<P>>>>,
-    A | B,
+    A | ReturnType<Fn>,
     Pr
   > => {
     const onMatch = args[args.length - 1] as any
@@ -403,7 +415,11 @@ export const tagsExhaustive = discriminatorsExhaustive("_tag")
  * @since 1.0.0
  */
 export const not =
-  <R, const P extends PatternPrimitive<R> | PatternBase<R>, Fn extends (_: NotMatch<R, P>) => unknown>(
+  <
+    R,
+    const P extends PatternPrimitive<R> | PatternBase<R>,
+    Fn extends (_: NotMatch<R, P>) => unknown,
+  >(
     pattern: P,
     f: Fn,
   ) =>
@@ -727,7 +743,7 @@ export const exhaustive: <I, F, A, Pr>(
 // combinations
 type WhenMatch<R, P> =
   // check for any
-  0 extends 1 & R
+  [0] extends [1 & R]
     ? PForMatch<P>
     : P extends SafeSchema<infer SP, never>
     ? SP

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,9 +217,9 @@ export const value = <I>(i: I): Matcher<I, Without<never>, I, never, I> =>
  * @since 1.0.0
  */
 export const when =
-  <R, const P extends PatternPrimitive<R> | PatternBase<R>, B>(
+  <R, const P extends PatternPrimitive<R> | PatternBase<R>, Fn extends (_: WhenMatch<R, P>) => unknown>(
     pattern: P,
-    f: (_: WhenMatch<R, P>) => B,
+    f: Fn,
   ) =>
   <I, F, A, Pr>(
     self: Matcher<I, F, R, A, Pr>,
@@ -227,7 +227,7 @@ export const when =
     I,
     AddWithout<F, PForExclude<P>>,
     ApplyFilters<I, AddWithout<F, PForExclude<P>>>,
-    A | B,
+    A | ReturnType<Fn>,
     Pr
   > =>
     (self as any).add(new When(makePredicate(pattern), f as any))
@@ -403,9 +403,9 @@ export const tagsExhaustive = discriminatorsExhaustive("_tag")
  * @since 1.0.0
  */
 export const not =
-  <R, const P extends PatternPrimitive<R> | PatternBase<R>, B>(
+  <R, const P extends PatternPrimitive<R> | PatternBase<R>, Fn extends (_: NotMatch<R, P>) => unknown>(
     pattern: P,
-    f: (_: NotMatch<R, P>) => B,
+    f: Fn,
   ) =>
   <I, F, A, Pr>(
     self: Matcher<I, F, R, A, Pr>,
@@ -413,7 +413,7 @@ export const not =
     I,
     AddOnly<F, WhenMatch<R, P>>,
     ApplyFilters<I, AddOnly<F, WhenMatch<R, P>>>,
-    A | B,
+    A | ReturnType<Fn>,
     Pr
   > =>
     (self as any).add(new Not(makePredicate(pattern), f as any))

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -710,20 +710,20 @@ describe("Matcher", () => {
 
   it("pattern type is not fixed by the function argument type", () => {
     type T =
-      | { resolveType: 'A', value: number }
-      | { resolveType: 'B', value: number }
-      | { resolveType: 'C', value: number };
+      | { resolveType: "A"; value: number }
+      | { resolveType: "B"; value: number }
+      | { resolveType: "C"; value: number }
 
-    const value = {resolveType: 'A', value: 12} as T;
+    const value = { resolveType: "A", value: 12 } as T
 
-    const doStuff = (x: { value: number }) => x;
+    const doStuff = (x: { value: number }) => x
 
     const result = pipe(
       M.value(value),
-      M.when({ resolveType: M.is('A', 'B') }, doStuff),
-      M.not({ resolveType: M.is('A', 'B') }, doStuff),
-      M.exhaustive
-    );
+      M.when({ resolveType: M.is("A", "B") }, doStuff),
+      M.not({ resolveType: M.is("A", "B") }, doStuff),
+      M.exhaustive,
+    )
 
     typeEquals(result)<{ value: number }>() satisfies true
   })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -707,4 +707,24 @@ describe("Matcher", () => {
     expect(match({})).toEqual("record")
     expect(match([])).toEqual("unknown")
   })
+
+  it("pattern type is not fixed by the function argument type", () => {
+    type T =
+      | { resolveType: 'A', value: number }
+      | { resolveType: 'B', value: number }
+      | { resolveType: 'C', value: number };
+
+    const value = {resolveType: 'A', value: 12} as T;
+
+    const doStuff = (x: { value: number }) => x;
+
+    const result = pipe(
+      M.value(value),
+      M.when({ resolveType: M.is('A', 'B') }, doStuff),
+      M.not({ resolveType: M.is('A', 'B') }, doStuff),
+      M.exhaustive
+    );
+
+    typeEquals(result)<{ value: number }>() satisfies true
+  })
 })


### PR DESCRIPTION
It looks like whenever there's a`Refinement` involved in the pattern and the function has a fixed input type (instead of being infered) the type of the pattern `P` is getting fixed using the inut type of the provided function. TLDR, my observation on the example provided in tests is that `P` seems to be infered using a type `WhenMatch<R, P>` which is fixed by the function type.

The idea of the proposed fix is that when the type `(_: WhenMatch<R, P>) => unknown` is used as a constraint instead of as a type that can be infered from provided value, it shouldn't contribute to the type inference of `P`. Indeed, it solved the found type issue.

Please note, the reasoning is based on observation, I have no idea how the ts inference work under the hood. Also, I didn't check deep enough to understand why the problem starts occuring only with refinements. 