### PR TITLE
feat: overload match value method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,11 @@ export type Matcher<Input, Filters, RemainingApplied, Result, Provided> =
   | TypeMatcher<Input, Filters, RemainingApplied, Result>
   | ValueMatcher<Input, Filters, RemainingApplied, Result, Provided>
 
+type ValueMatch = {
+  <I extends [any, ...any]>(i: I): Matcher<I, Without<never>, I, never, I>
+  <I>(i: I): Matcher<I, Without<never>, I, never, I>
+}
+
 class TypeMatcher<Input, Filters, Remaining, Result> {
   readonly _tag = "TypeMatcher"
   readonly _input: (_: Input) => unknown = identity
@@ -189,8 +194,7 @@ export const type = <I>(): Matcher<I, Without<never>, I, never, never> =>
  * @tsplus static effect/match/Matcher.Ops __call
  * @since 1.0.0
  */
-export const value = <I>(i: I): Matcher<I, Without<never>, I, never, I> =>
-  new ValueMatcher(i, E.left(i))
+export const value: ValueMatch = (i: any): any => new ValueMatcher(i, E.left(i))
 
 /**
  * @category constructors


### PR DESCRIPTION
Great library! I have been migrating some of my work to the effects ecosystem.

I use tuples to pattern match on different values using `ts-pattern`, but doing that with this lib, I have to add `as const` because the tuples are inferred as an Array instead.

For example:
```ts
...
const match1 = Match.value([true, 1])
const match2 = Match.value([true, true])
...
```
`match1`'s value gets inferred as  `(boolean | number)[]` and `match2`'s value gets inferred as `boolean[]`.

This PR adds an overload for the `value` method for matching with tuples without using `as const`.